### PR TITLE
Corrección en las importaciones para AsignarEquipoTest

### DIFF
--- a/gestionequipos/AsignarEquipoTest.java
+++ b/gestionequipos/AsignarEquipoTest.java
@@ -12,9 +12,9 @@
 
 package gestionequipos;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 import org.junit.jupiter.api.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class AsignarEquipoTest {
 	


### PR DESCRIPTION
Se establecen sólo las importaciones necesarias y no org.junit.Assert.* como estaba declarado